### PR TITLE
bump memsz in hex2_x86.hex1 to allow stage0-posix to work on Linux 2.…

### DIFF
--- a/hex2_x86.hex1
+++ b/hex2_x86.hex1
@@ -42,7 +42,7 @@
 00 80 04 08                     # ph_physaddr
 
 7D 05 00 00                     # ph_filesz
-7D 05 00 00                     # ph_memsz
+00 20 00 00                     # ph_memsz
 
 07 00 00 00                    # ph_flags: PF-X|PF-W|PF-R = 7
 01 00 00 00                    # ph_align


### PR DESCRIPTION
…2 and 2.4 kernels

Fix for #1 bump memsz to 8KB so that the scratch area used by hex2 doesn't get overwritten by brk (in theory bumping to 4KB would suffice, but 8KB gives a little more headroom). This only affected Linux 2.2 and 2.4 as those kernels do not seem to round up to the nearest 4KB boundry when the initial brk(0) call is make to read the initial value of brk. Because of this initial memory allocated by brk wil overlap the scratch area juts beyond the end of the hex2 binary (which then causes it to crash). eg before this patch we get a segfault on Linux 2.4. Using strace we can see that the first call to 
```
strace ./x86/artifact/hex2-0 ./x86/catm_x86.hex2 ./x86/artifact/catm
```
```
execve("./x86/artifact/hex2-0", ["./x86/artifact/hex2-0", "./x86/catm_x86.hex2", "./x86/artifact/catm"], [/* 31 vars */]) = 0
brk(0)                                  = 0x804857d
brk(0x8c4857d)                          = 0x8c4857d
open("./x86/catm_x86.hex2", O_RDONLY)   = 3
open("./x86/artifact/catm", O_WRONLY|O_CREAT|O_TRUNC, 0700) = 4
read(3, "#", 1)                         = 1
read(3, " ", 1)                         = 1
read(3, "S", 1)                         = 1
read(3, "P", 1)                         = 1
read(3, "D", 1)                         = 1
```
The above brk(0) value is 4 bytes after :table so allocated regions overlap and will cause memory corruption.