### PR TITLE
Add support for anonymous enums

### DIFF
--- a/GAS/cc_x86.S
+++ b/GAS/cc_x86.S
@@ -599,6 +599,10 @@ fputc:
 	pop ebx                     # Restore EBX
 	ret
 
+enum_error_open_curly: .asciz "ERROR in enum\nExpected {\n"
+enum_error_equal: .asciz "ERROR in enum\nExpected =\n"
+enum_error_close_curly: .asciz "ERROR in enum\nExpected }\n"
+enum_error_semi_colon: .asciz "ERROR in enum\nExpected ;\n"
 
 # program function
 # receives nothing, returns nothing
@@ -609,6 +613,80 @@ program:
 	push ecx                    # Protect ECX
 
 new_type:
+    mov eax, [global_token] # Using global_token
+    cmp eax, 0                  # Check if NULL
+    je program_done             # Be done if null
+
+    mov ebx, [eax+8]                  # GLOBAL_TOKEN->S
+    lea eax, [enum]                   # "enum"
+    call match                        # IF GLOBAL_TOKEN->S == "enum"
+    cmp eax, 0                        # If true
+    jne constant_value                # Looks like not an enum
+
+    # Deal with minimal anonymous enums
+    mov eax, [global_token]           # Using global_token
+    mov eax, [eax]                    # global_token->next
+    mov [global_token], eax           # global_token = global_token->next
+
+    lea eax, [enum_error_open_curly]  # Using "ERROR in enum\nExpected {\n"
+    lea ebx, [open_curly_brace]       # Using "{"
+    call require_match                # Require match and skip
+
+enumerator:
+    mov eax, [global_token]           # Using global token
+    mov eax, [eax+8]                  # global_token->s
+    mov ebx, 0                        # NULL
+    mov ecx, [global_constant_list]   # global_constant_list
+    call sym_declare                  # Declare the constant
+    mov [global_constant_list], eax   # global_constant_list = sym_declare(global_token->s, NULL, global_constant_list);
+
+    mov eax, [global_token]           # Using global_token
+    mov eax, [eax]                    # global_token->next
+    mov [global_token], eax           # global_token = global_token->next
+
+    lea eax, [enum_error_equal]       # Using "ERROR in enum\nExpected =\n"
+    lea ebx, [equal]                  # Using "="
+    call require_match                # Require match and skip
+
+    mov ebx, [global_token]           # Using global_token
+    mov eax, [global_constant_list]   # Use global_constant_list
+    mov [eax+16], ebx                 # global_constant_list->arguments = global_token
+
+    mov eax, [global_token]           # Using global_token
+    mov eax, [eax]                    # global_token->next
+    mov [global_token], eax           # global_token = global_token->next
+
+    mov eax, [global_token]           # Use global_token
+    mov ebx, [eax+8]                  # global_token->s
+    lea eax, [comma]                  # ","
+    call match                        # IF global_token->s == ","
+    cmp eax, 0                        # If true
+    jne enum_end                      # No comma means no more enumerators
+
+    # Skip comma
+    mov eax, [global_token]           # Using global_token
+    mov eax, [eax]                    # global_token->next
+    mov [global_token], eax           # global_token = global_token->next
+
+    # Check if there are more enumerators or if it was a trailing comma
+    mov ebx, [eax+8]                  # global_token->s
+    lea eax, [close_curly_brace]      # "}"
+    call match                        # IF global_token->s == "}"
+    cmp eax, 0                        # If true
+    jne enumerator                    # More enumerators
+
+enum_end:
+    lea eax, [enum_error_close_curly] # Using "ERROR in enum\nExpected }\n"
+    lea ebx, [close_curly_brace]      # Using "}"
+    call require_match                # Require match and skip
+
+    lea eax, [enum_error_semi_colon]  # Using "ERROR in enum\nExpected ;\n"
+    lea ebx, [semicolon]              # Using ";"
+    call require_match                # Require match and skip
+
+    jmp new_type                      # go around again
+
+constant_value:
 	mov eax, [global_token]     # Using global_token
 	cmp eax, 0                  # Check if NULL
 	je program_done             # Be done if null
@@ -4376,6 +4454,7 @@ Exit_Failure:
 # Keywords
 union: .asciz "union"
 struct: .asciz "struct"
+enum: .asciz "enum"
 constant: .asciz "CONSTANT"
 main_string: .asciz "main"
 argc_string: .asciz "argc"

--- a/NASM/cc_amd64.S
+++ b/NASM/cc_amd64.S
@@ -606,6 +606,10 @@ fputc:
 	pop ebx                     ; Restore EBX
 	ret
 
+enum_error_open_curly: db "ERROR in enum\nExpected {\n", 0
+enum_error_equal: db "ERROR in enum\nExpected =\n", 0
+enum_error_close_curly: db "ERROR in enum\nExpected }\n", 0
+enum_error_semi_colon: db "ERROR in enum\nExpected ;\n", 0
 
 ;; program function
 ;; receives nothing, returns nothing
@@ -616,6 +620,80 @@ program:
 	push ecx                    ; Protect ECX
 
 new_type:
+	mov eax, [global_token]     ; Using global_token
+	cmp eax, 0                  ; Check if NULL
+	je program_done             ; Be done if null
+
+	mov ebx, [eax+8]            ; GLOBAL_TOKEN->S
+	lea eax, [enum]             ; "enum"
+	call match                  ; IF GLOBAL_TOKEN->S == "enum"
+	cmp eax, 0                  ; If true
+	jne constant_value          ; Looks like not an enum
+
+	; Deal with minimal anonymous enums
+	mov eax, [global_token]           ; Using global_token
+	mov eax, [eax]                    ; global_token->next
+	mov [global_token], eax           ; global_token = global_token->next
+
+	lea eax, [enum_error_open_curly]  ; Using "ERROR in enum\nExpected {\n"
+	lea ebx, [open_curly_brace]       ; Using "{"
+	call require_match                ; Require match and skip
+
+enumerator:
+	mov eax, [global_token]           ; Using global token
+	mov eax, [eax+8]                  ; global_token->s
+	mov ebx, 0                        ; NULL
+	mov ecx, [global_constant_list]   ; global_constant_list
+	call sym_declare                  ; Declare the constant
+	mov [global_constant_list], eax   ; global_constant_list = sym_declare(global_token->s, NULL, global_constant_list);
+
+	mov eax, [global_token]           ; Using global_token
+	mov eax, [eax]                    ; global_token->next
+	mov [global_token], eax           ; global_token = global_token->next
+
+	lea eax, [enum_error_equal]       ; Using "ERROR in enum\nExpected =\n"
+	lea ebx, [equal]                  ; Using "="
+	call require_match                ; Require match and skip
+
+	mov ebx, [global_token]           ; Using global_token
+	mov eax, [global_constant_list]   ; Use global_constant_list
+	mov [eax+16], ebx                 ; global_constant_list->arguments = global_token
+
+	mov eax, [global_token]           ; Using global_token
+	mov eax, [eax]                    ; global_token->next
+	mov [global_token], eax           ; global_token = global_token->next
+
+	mov eax, [global_token]           ; Use global_token
+	mov ebx, [eax+8]                  ; global_token->s
+	lea eax, [comma]                  ; ","
+	call match                        ; IF global_token->s == ","
+	cmp eax, 0                        ; If true
+	jne enum_end                      ; No comma means no more enumerators
+
+	; Skip comma
+	mov eax, [global_token]           ; Using global_token
+	mov eax, [eax]                    ; global_token->next
+	mov [global_token], eax           ; global_token = global_token->next
+
+	; Check if there are more enumerators or if it was a trailing comma
+	mov ebx, [eax+8]                  ; global_token->s
+	lea eax, [close_curly_brace]      ; "}"
+	call match                        ; IF global_token->s == "}"
+	cmp eax, 0                        ; If true
+	jne enumerator                    ; More enumerators
+
+enum_end:
+	lea eax, [enum_error_close_curly] ; Using "ERROR in enum\nExpected }\n"
+	lea ebx, [close_curly_brace]      ; Using "}"
+	call require_match                ; Require match and skip
+
+	lea eax, [enum_error_semi_colon]  ; Using "ERROR in enum\nExpected ;\n"
+	lea ebx, [semicolon]              ; Using ";"
+	call require_match                ; Require match and skip
+
+	jmp new_type                      ; go around again
+
+constant_value:
 	mov eax, [global_token]     ; Using global_token
 	cmp eax, 0                  ; Check if NULL
 	je program_done             ; Be done if null
@@ -4383,6 +4461,7 @@ Exit_Failure:
 ;; Keywords
 union: db "union", 0
 struct: db "struct", 0
+enum: db "enum", 0
 constant: db "CONSTANT", 0
 main_string: db "main", 0
 argc_string: db "argc", 0

--- a/cc_x86.M1
+++ b/cc_x86.M1
@@ -745,6 +745,23 @@ DEFINE xchg_eax,ebx 93
 	ret
 
 
+:enum_error_open_curly
+"ERROR in enum
+Expected {
+"
+:enum_error_equal
+"ERROR in enum
+Expected =
+"
+:enum_error_close_curly
+"ERROR in enum
+Expected }
+"
+:enum_error_semi_colon
+"ERROR in enum
+Expected ;
+"
+
 # program function
 # receives nothing, returns nothing
 # Uses EAX for type_size
@@ -754,6 +771,80 @@ DEFINE xchg_eax,ebx 93
 	push_ecx                                    # Protect ECX
 
 :new_type
+    mov_eax,[DWORD] &global_token         # Using global_token
+    cmp_eax, !0                           # Check if NULL
+    je %program_done                      # Be done if null
+
+    mov_ebx,[eax+BYTE] !8                 # GLOBAL_TOKEN->S
+    mov_eax, &enum                        # "enum"
+    call %match                           # IF GLOBAL_TOKEN->S == "enum"
+    cmp_eax, !0                           # If true
+    jne %constant_value                   # Looks like not an enum
+
+    # Deal with minimal anonymous enums
+    mov_eax,[DWORD] &global_token         # Using global_token
+    mov_eax,[eax]                         # global_token->next
+    mov_[DWORD],eax &global_token         # global_token = global_token->next
+
+    mov_eax, &enum_error_open_curly       # Using "ERROR in enum\nExpected {\n"
+    mov_ebx, &open_curly_brace            # Using "{"
+    call %require_match                   # Require match and skip
+
+:enumerator
+    mov_eax,[DWORD] &global_token         # Using global token
+    mov_eax,[eax+BYTE] !8                 # global_token->S
+    mov_ebx, %0                           # NULL
+    mov_ecx,[DWORD] &global_constant_list # global_constant_list
+    call %sym_declare                     # Declare the constant
+    mov_[DWORD],eax &global_constant_list # global_constant_list = sym_declare(global_token->s, NULL, global_constant_list);
+
+    mov_eax,[DWORD] &global_token         # Using global_token
+    mov_eax,[eax]                         # global_token->next
+    mov_[DWORD],eax &global_token         # global_token = global_token->next
+
+    mov_eax, &enum_error_equal            # Using "ERROR in enum\nExpected =\n"
+    mov_ebx, &equal                       # Using "="
+    call %require_match                   # Require match and skip
+
+    mov_ebx,[DWORD] &global_token         # Using global_token
+    mov_eax,[DWORD] &global_constant_list # Use global_constant_list
+    mov_[eax+BYTE],ebx !16                # global_constant_list->arguments = global_token->next
+
+    mov_eax,[DWORD] &global_token         # Using global_token
+    mov_eax,[eax]                         # global_token->next
+    mov_[DWORD],eax &global_token         # global_token = global_token->next
+
+    mov_ebx,[DWORD] &global_token         # Use global_token
+    mov_ebx,[eax+BYTE] !8                 # global_token->s
+    mov_eax, &comma                       # ","
+    call %match                           # IF global_token->s == ","
+    cmp_eax, !0                           # If true
+    jne %enum_end                         # No comma means no more enumerators
+
+    # Skip comma
+    mov_eax,[DWORD] &global_token         # Using global_token
+    mov_eax,[eax]                         # global_token->next
+    mov_[DWORD],eax &global_token         # global_token = global_token->next
+
+    # Check if there are more enumerators or if it was a trailing comma
+    mov_ebx,[eax+BYTE] !8                 # global_token->s
+    mov_eax, &close_curly_brace           # "}"
+    call %match                           # IF global_token->s == "}"
+    cmp_eax, !0                           # If true
+    jne %enumerator                       # More enumerators
+
+:enum_end
+    mov_eax, &enum_error_close_curly      # Using "ERROR in enum\nExpected }\n"
+    mov_ebx, &close_curly_brace           # Using "}"
+    call %require_match                   # Require match and skip
+
+    mov_eax, &enum_error_semi_colon       # Using "ERROR in enum\nExpected ;\n"
+    mov_ebx, &semicolon                   # Using ";"
+    call %require_match                   # Require match and skip
+
+    jmp %new_type                         # go around again
+
+:constant_value
 	mov_eax,[DWORD] &global_token               # Using global_token
 	cmp_eax, !0                                 # Check if NULL
 	je %program_done                            # Be done if null
@@ -4688,6 +4779,7 @@ Missing ;
 # Keywords
 :union  "union"
 :struct  "struct"
+:enum  "enum"
 :constant  "CONSTANT"
 :main_string  "main"
 :argc_string  "argc"


### PR DESCRIPTION
This doesn't pass the bootstrap on my machine, but it also doesn't pass with the current master of `stage0-posix` and I can't repro it on simple files.

Test file:
```c
// CONSTANT TEST5 5
enum {
    TEST1 = 1,
    TEST2 = 2
};

enum {
    TEST3 = 3,
    TEST4 = 4,
};

int main() {
    return TEST1 + TEST2 + TEST3 + TEST4 + TEST5;
}
```

outputs

```
:FUNCTION_main
mov_eax, %1
push_eax	#_common_recursion
mov_eax, %2
pop_ebx	# _common_recursion
add_eax,ebx
push_eax	#_common_recursion
mov_eax, %3
pop_ebx	# _common_recursion
add_eax,ebx
push_eax	#_common_recursion
mov_eax, %4
pop_ebx	# _common_recursion
add_eax,ebx
push_eax	#_common_recursion
mov_eax, %5
pop_ebx	# _common_recursion
add_eax,ebx
ret

:ELF_end
```