### PR TITLE
Harden cc_x86 against malformed input

### DIFF
--- a/GAS/cc_x86.S
+++ b/GAS/cc_x86.S
@@ -204,11 +204,15 @@ get_token_comment:
 	mov [C], eax                # Set C
 get_token_comment_block_outer:
 	mov eax, [C]                # Using C
+	cmp eax, -4                 # Check for EOF
+	je reset                    # be done
 	cmp eax, 47                 # IF '/' != C
 	je get_token_comment_block_done # be done
 
 get_token_comment_block_inner:
 	mov eax, [C]                # Using C
+	cmp eax, -4                 # Check for EOF
+	je reset                    # be done
 	cmp eax, 42                 # IF '*' != C
 	je get_token_comment_block_iter # jump over
 
@@ -339,8 +343,11 @@ strings: .byte 34, 39, 0
 # returns line feed
 purge_macro:
 	call fgetc                  # read next char
+	cmp eax, -4                 # Check for EOF
+	je purge_macro_done         # Done if EOF
 	cmp eax, 10                 # Check for '\n'
 	jne purge_macro             # Keep going
+purge_macro_done:
 	ret
 
 
@@ -430,6 +437,8 @@ consume_word_escape:
 
 consume_word_iter:
 	call consume_byte           # read next char
+	cmp eax, -4                 # Check for EOF
+	je consume_word_done        # Stop if the string was not closed
 
 	cmp ecx, 0                  # IF ESCAPE
 	jne consume_word_loop       # keep looping
@@ -438,6 +447,7 @@ consume_word_iter:
 	jne consume_word_loop       # keep going
 
 	call fgetc                  # return next char
+consume_word_done:
 	pop ecx                     # Restore ECX
 	pop ebx                     # Restore EBX
 	ret
@@ -634,6 +644,8 @@ new_type:
 
 enumerator:
 	mov eax, [global_token]           # Using global token
+	cmp eax, 0                        # Check for EOF
+	je Exit_Failure                   # Missing enumerator
 	mov eax, [eax+8]                  # global_token->s
 	mov ebx, 0                        # NULL
 	mov ecx, [global_constant_list]   # global_constant_list
@@ -649,12 +661,16 @@ enumerator:
 	call require_match                # Require match and skip
 
 	mov ebx, [global_token]           # Using global_token
+	cmp ebx, 0                        # Check for EOF
+	je Exit_Failure                   # Missing enumerator value
 	mov eax, [global_constant_list]   # Use global_constant_list
 	mov [eax+16], ebx                 # global_constant_list->arguments = global_token
 
 	mov eax, [global_token]           # Using global_token
 	mov eax, [eax]                    # global_token->next
 	mov [global_token], eax           # global_token = global_token->next
+	cmp eax, 0                        # Check for EOF
+	je enum_end                       # Missing } will be reported below
 
 	mov eax, [global_token]           # Use global_token
 	mov ebx, [eax+8]                  # global_token->s
@@ -667,6 +683,8 @@ enumerator:
 	mov eax, [global_token]           # Using global_token
 	mov eax, [eax]                    # global_token->next
 	mov [global_token], eax           # global_token = global_token->next
+	cmp eax, 0                        # Check for EOF
+	je enum_end                       # Missing } will be reported below
 
 	# Check if there are more enumerators or if it was a trailing comma
 	mov ebx, [eax+8]                  # global_token->s
@@ -690,6 +708,9 @@ program_else:
 	call type_name              # Figure out the type_size
 	cmp eax, 0                  # IF NULL == type_size
 	je new_type                 # it was a new type
+	mov ebx, [global_token]     # Using global_token
+	cmp ebx, 0                  # Check for EOF
+	je program_error            # Missing declarator
 
 	# Add to global symbol table
 	mov ebx, eax                # put type_size in the right spot
@@ -701,6 +722,8 @@ program_else:
 	mov ebx, [global_token]     # Using global token
 	mov ebx, [ebx]              # global_token->next
 	mov [global_token], ebx     # global_token = global_token->next
+	cmp ebx, 0                  # Check for EOF
+	je program_error            # Missing ; or function body
 
 	mov ebx, [global_token]     # Using global token
 	mov ebx, [ebx+8]            # global_token->S
@@ -744,7 +767,7 @@ program_function:
 
 program_error:
 	# Deal with the case of something we don't support
-	# NOT IMPLEMENTED
+	jmp Exit_Failure            # Abort
 
 program_done:
 	pop ecx                     # Restore ECX
@@ -777,6 +800,8 @@ declare_function:
 	call collect_arguments      # collect all of the function arguments
 
 	mov eax, [global_token]     # Using global token
+	cmp eax, 0                  # Check for EOF
+	je Exit_Failure             # Missing prototype ; or body
 	mov eax, [eax+8]            # global token->s
 	mov ebx, OFFSET semicolon   # ";"
 	call match                  # IF global token->s == ";"
@@ -845,6 +870,8 @@ collect_arguments:
 	mov [global_token], eax     # global_token = global_token->next
 collect_arguments_loop:
 	mov ebx, [global_token]     # Using global_token
+	cmp ebx, 0                  # Check for EOF
+	je Exit_Failure             # Missing )
 	mov ebx, [ebx+8]            # global_token->S
 	mov eax, OFFSET close_paren # ")"
 	call match                  # IF global_token->S == ")"
@@ -854,6 +881,9 @@ collect_arguments_loop:
 	# deal with the case of there are arguments
 	call type_name              # Get the type
 	mov ecx, eax                # put type_size safely out of the way
+	mov ebx, [global_token]     # Using global_token
+	cmp ebx, 0                  # Check for EOF
+	je Exit_Failure             # Missing argument or )
 
 	mov ebx, [global_token]     # Using global_token
 	mov ebx, [ebx+8]            # global_token->S
@@ -907,6 +937,8 @@ collect_arguments_next:
 
 collect_arguments_common:
 	mov ebx, [global_token]     # Using global_token
+	cmp ebx, 0                  # Check for EOF
+	je Exit_Failure             # Missing )
 	mov ebx, [ebx+8]            # global_token->S
 	mov eax, OFFSET comma       # ","
 	call match                  # IF global_token->S == ","
@@ -917,6 +949,8 @@ collect_arguments_common:
 	mov eax, [global_token]     # Using global_token
 	mov eax, [eax]              # global_token->next
 	mov [global_token], eax     # global_token = global_token->next
+	cmp eax, 0                  # Check for EOF
+	je Exit_Failure             # Missing argument after comma
 	jmp collect_arguments_loop  # keep going
 
 collect_arguments_done:
@@ -937,6 +971,8 @@ statement:
 	push ecx                    # Protect ECX
 
 	mov ebx, [global_token]     # Using global_token
+	cmp ebx, 0                  # Check for EOF
+	je Exit_Failure             # Missing statement
 	mov ebx, [ebx+8]            # global_token->S
 	mov eax, OFFSET open_curly_brace # "{"
 	call match                  # IF global_token->S == "{"
@@ -1046,6 +1082,8 @@ statement_goto:
 	mov eax, [global_token]     # Using global_token
 	mov eax, [eax]              # global_token->next
 	mov [global_token], eax     # global_token = global_token->next
+	cmp eax, 0                  # IF we hit EOF
+	je Exit_Failure             # Abort hard
 
 	mov eax, [eax+8]            # global_token->S
 	call emit_out               # emit it
@@ -1137,6 +1175,8 @@ recursive_statement:
 
 recursive_statement_loop:
 	mov ebx, [global_token]     # Using global_token
+	cmp ebx, 0                  # Check for EOF
+	je Exit_Failure             # Missing }
 	mov ebx, [ebx+8]            # global_token->S
 	mov eax, OFFSET close_curly_brace # Using "}"
 	call match                  # IF global_token->S == "}"
@@ -1195,6 +1235,8 @@ return_result:
 	mov eax, [global_token]     # Using global_token
 	mov eax, [eax]              # global_token->next
 	mov [global_token], eax     # global_token = global_token->next
+	cmp eax, 0                  # Check for EOF
+	je return_result_cleanup    # Missing ; will be reported below
 
 	mov eax, [eax+8]            # global_token->S
 	mov al, [eax]               # global_token->S[0]
@@ -1244,6 +1286,8 @@ collect_local:
 
 	mov ebx, eax                # Put struct type* type_size in the right place
 	mov eax, [global_token]     # Using global_token
+	cmp eax, 0                  # Check for EOF
+	je Exit_Failure             # Missing local name
 	mov eax, [eax+8]            # global_token->S
 	mov ecx, [function]         # Using function
 	mov ecx, [ecx+4]            # function->locals
@@ -1326,6 +1370,8 @@ collect_local_common:
 	mov eax, [global_token]     # Using global_token
 	mov eax, [eax]              # global_token->NEXT
 	mov [global_token], eax     # global_token = global_token->NEXT
+	cmp eax, 0                  # Check for EOF
+	je collect_local_done       # Missing ; will be reported below
 
 	mov ebx, [eax+8]            # global_token->S
 	mov eax, OFFSET equal       # Using "="
@@ -1381,6 +1427,8 @@ process_asm:
 
 	mov ebx, [global_token]     # Using global_token
 process_asm_iter:
+	cmp ebx, 0                  # IF we hit EOF
+	je process_asm_done         # report the missing close paren
 	mov eax, [ebx+8]            # global_token->S
 	mov al, [eax]               # global_token->S[0]
 	movzx eax, al               # Make it useful
@@ -1479,6 +1527,8 @@ process_if:
 	call uniqueID_out           # uniqueID_out(function->s, number_string)
 
 	mov ebx, [global_token]     # Using global_token
+	cmp ebx, 0                  # Check for EOF
+	je process_if_done          # No else branch
 	mov ebx, [ebx+8]            # global_token->S
 	mov eax, OFFSET else_string # Using "else"
 	call match                  # IF global_token->S == "else"
@@ -1778,6 +1828,8 @@ process_for:
 	call require_match          # Make Sure we have it
 
 	mov ebx, [global_token]     # Using global_token
+	cmp ebx, 0                  # IF we hit EOF
+	je Exit_Failure             # Abort hard
 	mov ebx, [ebx+8]            # global_token->S
 	mov eax, OFFSET semicolon   # Using ";"
 	call match                  # IF global_token->S == ";"
@@ -1977,6 +2029,8 @@ expression:
 	call bitwise_expr           # Collect bitwise expressions
 
 	mov ebx, [global_token]     # Using global_token
+	cmp ebx, 0                  # Check for EOF
+	je expression_done          # Nothing left to assign
 	mov ebx, [ebx+8]            # global_token->S
 	mov eax, OFFSET equal       # "="
 	call match                  # IF global_token->S == "="
@@ -2249,6 +2303,8 @@ postfix_expr:
 postfix_expr_stub:
 	push ebx                    # Protect EBX
 	mov ebx, [global_token]     # Using global_token
+	cmp ebx, 0                  # Check for EOF
+	je postfix_expr_stub_done   # No postfix suffix
 	mov ebx, [ebx+8]            # global_token->S
 	mov eax, OFFSET open_bracket # Using "["
 	call match                  # IF global_token->S == "["
@@ -2324,6 +2380,8 @@ postfix_expr_array:
 	push ebx                    # Protect EBX
 	push ecx                    # Protect ECX
 	mov eax, [current_target]   # ARRAY = current_target
+	cmp eax, 0                  # Check for bad target
+	je Exit_Failure             # Cannot subscript unknown target
 	push eax                    # Protect it
 
 	mov eax, OFFSET expression  # Using expression
@@ -2351,6 +2409,8 @@ postfix_expr_array_large:
 
 	mov eax, [current_target]   # Using current_target
 	mov eax, [eax+12]           # current_target->INDIRECT
+	cmp eax, 0                  # IF target is not indexable
+	je Exit_Failure             # Abort hard
 	mov eax, [eax+4]            # current_target->INDIRECT->SIZE
 	call ceil_log2              # ceil_log2(current_target->indirect->size)
 	call numerate_number        # numerate_number(ceil_log2(current_target->indirect->size))
@@ -2368,6 +2428,8 @@ postfix_expr_array_common:
 	call require_match          # Make sure we have it
 
 	mov ebx, [global_token]     # Using global_token
+	cmp ebx, 0                  # IF we hit EOF
+	je postfix_expr_array_done  # Treat it as not being an assignment
 	mov ebx, [ebx+8]            # global_token->S
 	mov eax, OFFSET equal       # Using "="
 	call match                  # IF global_token->S == "="
@@ -2440,8 +2502,16 @@ postfix_expr_arrow:
 	mov eax, [global_token]     # Using global_token
 	mov eax, [eax]              # global_token->NEXT
 	mov [global_token], eax     # global_token = global_token->NEXT
+	cmp eax, 0                  # IF we hit EOF
+	je Exit_Failure             # Abort hard
 
 	mov ebx, [eax+8]            # Using global_token->S
+	mov eax, [current_target]   # Using current_target
+	cmp eax, 0                  # IF target is unknown
+	je Exit_Failure             # Abort hard
+	mov eax, [eax+16]           # current_target->MEMBERS
+	cmp eax, 0                  # IF target has no members
+	je Exit_Failure             # Abort hard
 	mov eax, [current_target]   # Using current_target
 	call lookup_member          # lookup_member(current_target, global_token->s)
 	mov ebx, eax                # struct type* I = lookup_member(current_target, global_token->s)
@@ -2475,6 +2545,8 @@ postfix_expr_arrow_first:
 
 	# Last chance for load
 	mov eax, [global_token]     # Using global_token
+	cmp eax, 0                  # IF we hit EOF
+	je postfix_expr_arrow_load  # Treat it as not being an assignment
 	mov ebx, [eax+8]            # global_token->S
 	mov eax, OFFSET equal       # Using "="
 	call match                  # IF global_token->S == "="
@@ -2482,6 +2554,7 @@ postfix_expr_arrow_first:
 	je postfix_expr_arrow_done  # Be done
 
 	# Deal with load case
+postfix_expr_arrow_load:
 	mov eax, OFFSET postfix_expr_arrow_string_3 # Using "mov_eax,[eax]\n"
 	call emit_out               # Emit it
 
@@ -2502,6 +2575,8 @@ primary_expr:
 	push ebx                    # Protect EBX
 
 	mov eax, [global_token]     # Using global_token
+	cmp eax, 0                  # Check for EOF
+	je Exit_Failure             # Missing expression
 	mov ebx, [eax+8]            # global_token->S
 	mov eax, OFFSET sizeof_string # Using "sizeof"
 	call match                  # See if match
@@ -2778,6 +2853,8 @@ function_call:
 	call emit_out               # Emit it
 
 	mov eax, [global_token]     # Using global_token
+	cmp eax, 0                  # Check for EOF
+	je function_call_gen_done   # Missing ) will be reported below
 	mov eax, [eax+8]            # global_token->S
 	mov al, [eax]               # global_token->S[0]
 	movzx eax, al               # Make it useful
@@ -2793,6 +2870,8 @@ function_call:
 
 function_call_gen_iter:
 	mov eax, [global_token]     # Using global_token
+	cmp eax, 0                  # Check for EOF
+	je function_call_gen_done   # Missing ) will be reported below
 	mov eax, [eax+8]            # global_token->S
 	mov al, [eax]               # global_token->S[0]
 	movzx eax, al               # Make it useful
@@ -2906,6 +2985,8 @@ variable_load:
 	mov ecx, eax                # Protect A
 
 	mov ebx, [global_token]     # Using global_token
+	cmp ebx, 0                  # Check for EOF
+	je variable_load_regular    # EOF means not a call
 	mov ebx, [ebx+8]            # global_token->S
 	mov eax, OFFSET open_paren  # Using "("
 	call match                  # IF global_token->S == "("
@@ -2942,6 +3023,8 @@ variable_load_regular:
 
 	# Check for special case of assignment
 	mov ebx, [global_token]     # Using global_token
+	cmp ebx, 0                  # Check for EOF
+	je variable_load_value      # EOF means not an assignment
 	mov ebx, [ebx+8]            # global_token->S
 	mov eax, OFFSET equal       # Using "="
 	call match                  # IF global_token->S == "="
@@ -2949,6 +3032,7 @@ variable_load_regular:
 	je variable_load_done       # And be done
 
 	# Deal with common case
+variable_load_value:
 	mov eax, OFFSET variable_load_string_2 # Using "mov_eax,[eax]\n"
 	call emit_out               # Emit it
 
@@ -2972,6 +3056,8 @@ function_load:
 	mov eax, [eax+8]            # A->S
 	mov ecx, eax                # Protect A->S
 	mov ebx, [global_token]     # Using global_token
+	cmp ebx, 0                  # Check for EOF
+	je function_load_regular    # EOF means not a call
 	mov ebx, [ebx+8]            # global_token->S
 	mov eax, OFFSET open_paren  # Using "("
 	call match                  # IF global_token->S == "("
@@ -3025,6 +3111,8 @@ global_load:
 	call emit_out               # Emit it
 
 	mov ebx, [global_token]     # Using global_token
+	cmp ebx, 0                  # Check for EOF
+	je global_load_value        # EOF means this is not an assignment
 	mov ebx, [ebx+8]            # global_token->S
 	mov eax, OFFSET equal       # "="
 	call match                  # IF global_token->S == "="
@@ -3032,6 +3120,7 @@ global_load:
 	je global_load_done         # and be done
 
 	# Otherwise we are loading the contents
+global_load_value:
 	mov eax, OFFSET global_load_string_2 # Using "mov_eax,[eax]\n"
 	call emit_out               # Emit it
 
@@ -3219,6 +3308,8 @@ general_recursion:
 	mov ecx, ebx                # Protect S
 
 	mov ebx, [global_token]     # Using global_token
+	cmp ebx, 0                  # Check for EOF
+	je general_recursion_done   # Nothing left to match
 	mov ebx, [ebx+8]            # global_token->S
 	call match                  # IF match(name, global_token->s)
 	cmp eax, 0                  # If true we do
@@ -3334,11 +3425,14 @@ require_match:
 	push ecx                    # Protect ECX
 	mov ecx, eax                # put the message somewhere safe
 	mov eax, [global_token]     # Using global_token
+	cmp eax, 0                  # Check for EOF
+	je require_match_bad        # Missing required token
 	mov eax, [eax+8]            # global_token->S
 	call match                  # IF required == global_token->S
 	cmp eax, 0                  # we are fine
 	je require_match_good       # otherwise pain
 
+require_match_bad:
 	# Deal with bad times
 #	call line_error             # Tell user what went wrong
 	mov eax, 2                  # Using standard error
@@ -3783,6 +3877,8 @@ type_name:
 	push ebx                    # Protect EBX
 	push ecx                    # Protect ECX
 	mov ebx, [global_token]     # Using global_token
+	cmp ebx, 0                  # IF we hit EOF
+	je Exit_Failure             # Abort hard
 	mov ebx, [ebx+8]            # global_token->S
 	mov eax, OFFSET struct      # Using "struct"
 	call match                  # IF global_token->S == "struct"
@@ -3794,6 +3890,8 @@ type_name:
 	mov ebx, [global_token]     # Using global_token
 	mov ebx, [ebx]              # global_token->next
 	mov [global_token], ebx     # global_token = global_token->next
+	cmp ebx, 0                  # IF we hit EOF
+	je Exit_Failure             # Abort hard
 	mov eax, [ebx+8]            # global_token->S
 	mov ebx, [global_types]     # get all known types
 	call lookup_type            # Find type if possible
@@ -3839,6 +3937,8 @@ type_name_common:
 	mov [global_token], ebx     # global_token = global_token->next
 
 type_name_iter:
+	cmp ebx, 0                  # Check for EOF
+	je type_name_done           # No more pointer qualifiers
 	mov eax, [ebx+8]            # global_token->S
 	mov al, [eax]               # global_token->S[0]
 	movzx eax, al               # make it useful
@@ -3922,6 +4022,8 @@ create_struct:
 
 	mov [edx+12], ebp           # HEAD->INDIRECT = I
 	mov [ebp+12], edx           # I->INDIRECT = HEAD
+	mov [edx+20], edx           # HEAD->TYPE = HEAD
+	mov [ebp+20], ebp           # I->TYPE = I
 
 	mov eax, [global_types]     # Using global_types
 	mov [edx], eax              # HEAD->NEXT = global_types
@@ -3942,6 +4044,8 @@ create_struct:
 
 create_struct_iter:
 	mov eax, [global_token]     # Using global_token
+	cmp eax, 0                  # IF we hit EOF
+	je Exit_Failure             # Abort hard
 	mov eax, [eax+8]            # global_token->S
 	mov al, [eax]               # global_token->S[0]
 	movzx eax, al               # Make it useful
@@ -4061,10 +4165,14 @@ build_member:
 	mov ecx, eax                # Put in place
 	mov [edx+20], ecx           # I->TYPE = MEMBER_TYPE
 	mov eax, [global_token]     # Using global_token
+	cmp eax, 0                  # IF we hit EOF
+	je Exit_Failure             # Abort hard
 	mov ebx, [eax+8]            # global_token->S
 	mov [edx+24], ebx           # I->NAME = global_token->S
 	mov eax, [eax]              # global_token->NEXT
 	mov [global_token], eax     # global_token = global_token->NEXT
+	cmp eax, 0                  # IF we hit EOF
+	je build_member_non_array   # Let the caller report the missing semicolon
 
 	# Check if we have an array
 	mov ebx, [eax+8]            # global_token->S
@@ -4074,6 +4182,7 @@ build_member:
 	je build_member_array       # So deal with that pain
 
 	# Deal with non-array case
+build_member_non_array:
 	mov eax, [ecx+4]            # member_type->SIZE
 	mov [edx+4], eax            # I->SIZE = member_type->SIZE
 	jmp build_member_done       # Be done
@@ -4082,6 +4191,8 @@ build_member_array:
 	mov eax, [global_token]     # Using global_token
 	mov eax, [eax]              # global_token->NEXT
 	mov [global_token], eax     # global_token = global_token->NEXT
+	cmp eax, 0                  # IF we hit EOF
+	je Exit_Failure             # Abort hard
 
 	mov eax, [eax+8]            # global_token->S
 	call numerate_string        # convert number

--- a/cc_x86.M1
+++ b/cc_x86.M1
@@ -107,6 +107,7 @@ DEFINE mov_[eax+BYTE],ebx 8958
 DEFINE mov_[eax+BYTE],ecx 8948
 DEFINE mov_[eax+BYTE],edx 8950
 DEFINE mov_[ebp+BYTE],eax 8945
+DEFINE mov_[ebp+BYTE],ebp 896D
 DEFINE mov_[ebp+BYTE],edx 8955
 DEFINE mov_[ebp+BYTE],esi 8975
 DEFINE mov_[ebx],eax 8903
@@ -116,6 +117,7 @@ DEFINE mov_[edx+BYTE],eax 8942
 DEFINE mov_[edx+BYTE],ebp 896A
 DEFINE mov_[edx+BYTE],ebx 895A
 DEFINE mov_[edx+BYTE],ecx 894A
+DEFINE mov_[edx+BYTE],edx 8952
 DEFINE mov_[edx+BYTE],esi 8972
 DEFINE movzx_eax,al 0FB6C0
 DEFINE movzx_ebx,bl 0FB6DB
@@ -349,11 +351,15 @@ DEFINE xchg_eax,ebx 93
 	mov_[DWORD],eax &C                          # Set C
 :get_token_comment_block_outer
 	mov_eax,[DWORD] &C                          # Using C
+	cmp_eax, !-4                                # Check for EOF
+	je %reset                                   # be done
 	cmp_eax, !47                                # IF '/' != C
 	je %get_token_comment_block_done            # be done
 
 :get_token_comment_block_inner
 	mov_eax,[DWORD] &C                          # Using C
+	cmp_eax, !-4                                # Check for EOF
+	je %reset                                   # be done
 	cmp_eax, !42                                # IF '*' != C
 	je %get_token_comment_block_iter            # jump over
 
@@ -484,8 +490,11 @@ DEFINE xchg_eax,ebx 93
 # returns line feed
 :purge_macro
 	call %fgetc                                 # read next char
+	cmp_eax, !-4                                # Check for EOF
+	je %purge_macro_done                        # Done if EOF
 	cmp_eax, !10                                # Check for '\n'
 	jne %purge_macro                            # Keep going
+:purge_macro_done
 	ret
 
 
@@ -575,6 +584,8 @@ DEFINE xchg_eax,ebx 93
 
 :consume_word_iter
 	call %consume_byte                          # read next char
+	cmp_eax, !-4                                # Check for EOF
+	je %consume_word_done                       # Stop if the string was not closed
 
 	cmp_ecx, !0                                 # IF ESCAPE
 	jne %consume_word_loop                      # keep looping
@@ -583,6 +594,7 @@ DEFINE xchg_eax,ebx 93
 	jne %consume_word_loop                      # keep going
 
 	call %fgetc                                 # return next char
+:consume_word_done
 	pop_ecx                                     # Restore ECX
 	pop_ebx                                     # Restore EBX
 	ret
@@ -792,6 +804,8 @@ Expected ;
 
 :enumerator
 	mov_eax,[DWORD] &global_token         # Using global token
+	cmp_eax, !0                           # Check for EOF
+	je %Exit_Failure                      # Missing enumerator
 	mov_eax,[eax+BYTE] !8                 # global_token->S
 	mov_ebx, %0                           # NULL
 	mov_ecx,[DWORD] &global_constant_list # global_constant_list
@@ -801,18 +815,24 @@ Expected ;
 	mov_eax,[DWORD] &global_token         # Using global_token
 	mov_eax,[eax]                         # global_token->next
 	mov_[DWORD],eax &global_token         # global_token = global_token->next
+	cmp_eax, !0                           # Check for EOF
+	je %enum_end                          # Missing } will be reported below
 
 	mov_eax, &enum_error_equal            # Using "ERROR in enum\nExpected =\n"
 	mov_ebx, &equal                       # Using "="
 	call %require_match                   # Require match and skip
 
 	mov_ebx,[DWORD] &global_token         # Using global_token
+	cmp_ebx, !0                           # Check for EOF
+	je %Exit_Failure                      # Missing enumerator value
 	mov_eax,[DWORD] &global_constant_list # Use global_constant_list
 	mov_[eax+BYTE],ebx !16                # global_constant_list->arguments = global_token->next
 
 	mov_eax,[DWORD] &global_token         # Using global_token
 	mov_eax,[eax]                         # global_token->next
 	mov_[DWORD],eax &global_token         # global_token = global_token->next
+	cmp_eax, !0                           # Check for EOF
+	je %enum_end                          # Missing } will be reported below
 
 	mov_ebx,[DWORD] &global_token         # Use global_token
 	mov_ebx,[eax+BYTE] !8                 # global_token->s
@@ -848,6 +868,9 @@ Expected ;
 	call %type_name                             # Figure out the type_size
 	cmp_eax, !0                                 # IF NULL == type_size
 	je %new_type                                # it was a new type
+	mov_ebx,[DWORD] &global_token               # Using global_token
+	cmp_ebx, !0                                 # Check for EOF
+	je %program_error                           # Missing declarator
 
 	# Add to global symbol table
 	mov_ebx,eax                                 # put type_size in the right spot
@@ -859,6 +882,8 @@ Expected ;
 	mov_ebx,[DWORD] &global_token               # Using global token
 	mov_ebx,[ebx]                               # global_token->next
 	mov_[DWORD],ebx &global_token               # global_token = global_token->next
+	cmp_ebx, !0                                 # Check for EOF
+	je %program_error                           # Missing ; or function body
 
 	mov_ebx,[DWORD] &global_token               # Using global token
 	mov_ebx,[ebx+BYTE] !8                       # global_token->S
@@ -902,7 +927,7 @@ Expected ;
 
 :program_error
 	# Deal with the case of something we don't support
-	# NOT IMPLEMENTED
+	jmp %Exit_Failure                           # Abort
 
 :program_done
 	pop_ecx                                     # Restore ECX
@@ -926,6 +951,8 @@ NULL
 	mov_[DWORD],eax &current_count              # current_count = 0
 
 	mov_eax,[DWORD] &global_token               # Using global token
+	cmp_eax, !0                                 # Check for EOF
+	je %Exit_Failure                            # Missing prototype ; or body
 	mov_eax,[eax+BYTE] !4                       # global token->prev
 	mov_eax,[eax+BYTE] !8                       # global token->prev->s
 	mov_ebx, %0                                 # NULL
@@ -1008,6 +1035,8 @@ NULL
 	mov_[DWORD],eax &global_token               # global_token = global_token->next
 :collect_arguments_loop
 	mov_ebx,[DWORD] &global_token               # Using global_token
+	cmp_ebx, !0                                 # Check for EOF
+	je %Exit_Failure                            # Missing )
 	mov_ebx,[ebx+BYTE] !8                       # global_token->S
 	mov_eax, &close_paren                       # ")"
 	call %match                                 # IF global_token->S == ")"
@@ -1017,6 +1046,9 @@ NULL
 	# deal with the case of there are arguments
 	call %type_name                             # Get the type
 	mov_ecx,eax                                 # put type_size safely out of the way
+	mov_ebx,[DWORD] &global_token               # Using global_token
+	cmp_ebx, !0                                 # Check for EOF
+	je %Exit_Failure                            # Missing argument or )
 
 	mov_ebx,[DWORD] &global_token               # Using global_token
 	mov_ebx,[ebx+BYTE] !8                       # global_token->S
@@ -1070,6 +1102,8 @@ NULL
 
 :collect_arguments_common
 	mov_ebx,[DWORD] &global_token               # Using global_token
+	cmp_ebx, !0                                 # Check for EOF
+	je %Exit_Failure                            # Missing )
 	mov_ebx,[ebx+BYTE] !8                       # global_token->S
 	mov_eax, &comma                             # ","
 	call %match                                 # IF global_token->S == ","
@@ -1080,6 +1114,8 @@ NULL
 	mov_eax,[DWORD] &global_token               # Using global_token
 	mov_eax,[eax]                               # global_token->next
 	mov_[DWORD],eax &global_token               # global_token = global_token->next
+	cmp_eax, !0                                 # Check for EOF
+	je %Exit_Failure                            # Missing argument after comma
 	jmp %collect_arguments_loop                 # keep going
 
 :collect_arguments_done
@@ -1100,6 +1136,8 @@ NULL
 	push_ecx                                    # Protect ECX
 
 	mov_ebx,[DWORD] &global_token               # Using global_token
+	cmp_ebx, !0                                 # Check for EOF
+	je %Exit_Failure                            # Missing statement
 	mov_ebx,[ebx+BYTE] !8                       # global_token->S
 	mov_eax, &open_curly_brace                  # "{"
 	call %match                                 # IF global_token->S == "{"
@@ -1209,6 +1247,8 @@ NULL
 	mov_eax,[DWORD] &global_token               # Using global_token
 	mov_eax,[eax]                               # global_token->next
 	mov_[DWORD],eax &global_token               # global_token = global_token->next
+	cmp_eax, !0                                 # IF we hit EOF
+	je %Exit_Failure                            # Abort hard
 
 	mov_eax,[eax+BYTE] !8                       # global_token->S
 	call %emit_out                              # emit it
@@ -1306,6 +1346,8 @@ Missing ;
 
 :recursive_statement_loop
 	mov_ebx,[DWORD] &global_token               # Using global_token
+	cmp_ebx, !0                                 # Check for EOF
+	je %Exit_Failure                            # Missing }
 	mov_ebx,[ebx+BYTE] !8                       # global_token->S
 	mov_eax, &close_curly_brace                 # Using "}"
 	call %match                                 # IF global_token->S == "}"
@@ -1366,6 +1408,8 @@ Missing ;
 	mov_eax,[DWORD] &global_token               # Using global_token
 	mov_eax,[eax]                               # global_token->next
 	mov_[DWORD],eax &global_token               # global_token = global_token->next
+	cmp_eax, !0                                 # Check for EOF
+	je %return_result_cleanup                   # Missing ; will be reported below
 
 	mov_eax,[eax+BYTE] !8                       # global_token->S
 	mov_al,[eax]                                # global_token->S[0]
@@ -1419,6 +1463,8 @@ MISSING ;
 
 	mov_ebx,eax                                 # Put struct type* type_size in the right place
 	mov_eax,[DWORD] &global_token               # Using global_token
+	cmp_eax, !0                                 # Check for EOF
+	je %Exit_Failure                            # Missing local name
 	mov_eax,[eax+BYTE] !8                       # global_token->S
 	mov_ecx,[DWORD] &function                   # Using function
 	mov_ecx,[ecx+BYTE] !4                       # function->locals
@@ -1501,6 +1547,8 @@ MISSING ;
 	mov_eax,[DWORD] &global_token               # Using global_token
 	mov_eax,[eax]                               # global_token->NEXT
 	mov_[DWORD],eax &global_token               # global_token = global_token->NEXT
+	cmp_eax, !0                                 # Check for EOF
+	je %collect_local_done                      # Missing ; will be reported below
 
 	mov_ebx,[eax+BYTE] !8                       # global_token->S
 	mov_eax, &equal                             # Using "="
@@ -1559,6 +1607,8 @@ Missing ;
 
 	mov_ebx,[DWORD] &global_token               # Using global_token
 :process_asm_iter
+	cmp_ebx, !0                                 # IF we hit EOF
+	je %process_asm_done                        # report the missing close paren
 	mov_eax,[ebx+BYTE] !8                       # global_token->S
 	mov_al,[eax]                                # global_token->S[0]
 	movzx_eax,al                                # Make it useful
@@ -1664,6 +1714,8 @@ MISSING ;
 	call %uniqueID_out                          # uniqueID_out(function->s, number_string)
 
 	mov_ebx,[DWORD] &global_token               # Using global_token
+	cmp_ebx, !0                                 # Check for EOF
+	je %process_if_done                         # No else branch
 	mov_ebx,[ebx+BYTE] !8                       # global_token->S
 	mov_eax, &else_string                       # Using "else"
 	call %match                                 # IF global_token->S == "else"
@@ -1982,6 +2034,8 @@ MISSING )
 	call %require_match                         # Make Sure we have it
 
 	mov_ebx,[DWORD] &global_token               # Using global_token
+	cmp_ebx, !0                                 # IF we hit EOF
+	je %Exit_Failure                            # Abort hard
 	mov_ebx,[ebx+BYTE] !8                       # global_token->S
 	mov_eax, &semicolon                         # Using ";"
 	call %match                                 # IF global_token->S == ";"
@@ -2194,6 +2248,8 @@ Missing ;
 	call %bitwise_expr                          # Collect bitwise expressions
 
 	mov_ebx,[DWORD] &global_token               # Using global_token
+	cmp_ebx, !0                                 # Check for EOF
+	je %expression_done                         # Nothing left to assign
 	mov_ebx,[ebx+BYTE] !8                       # global_token->S
 	mov_eax, &equal                             # "="
 	call %match                                 # IF global_token->S == "="
@@ -2506,6 +2562,8 @@ sar_eax,cl
 :postfix_expr_stub
 	push_ebx                                    # Protect EBX
 	mov_ebx,[DWORD] &global_token               # Using global_token
+	cmp_ebx, !0                                 # Check for EOF
+	je %postfix_expr_stub_done                  # No postfix suffix
 	mov_ebx,[ebx+BYTE] !8                       # global_token->S
 	mov_eax, &open_bracket                      # Using "["
 	call %match                                 # IF global_token->S == "["
@@ -2586,6 +2644,8 @@ Missing )
 	push_ebx                                    # Protect EBX
 	push_ecx                                    # Protect ECX
 	mov_eax,[DWORD] &current_target             # ARRAY = current_target
+	cmp_eax, !0                                 # Check for bad target
+	je %Exit_Failure                            # Cannot subscript unknown target
 	push_eax                                    # Protect it
 
 	mov_eax, &expression                        # Using expression
@@ -2613,6 +2673,8 @@ Missing )
 
 	mov_eax,[DWORD] &current_target             # Using current_target
 	mov_eax,[eax+BYTE] !12                      # current_target->INDIRECT
+	cmp_eax, !0                                 # IF target is not indexable
+	je %Exit_Failure                            # Abort hard
 	mov_eax,[eax+BYTE] !4                       # current_target->INDIRECT->SIZE
 	call %ceil_log2                             # ceil_log2(current_target->indirect->size)
 	call %numerate_number                       # numerate_number(ceil_log2(current_target->indirect->size))
@@ -2630,6 +2692,8 @@ Missing )
 	call %require_match                         # Make sure we have it
 
 	mov_ebx,[DWORD] &global_token               # Using global_token
+	cmp_ebx, !0                                 # IF we hit EOF
+	je %postfix_expr_array_done                 # Treat it as not being an assignment
 	mov_ebx,[ebx+BYTE] !8                       # global_token->S
 	mov_eax, &equal                             # Using "="
 	call %match                                 # IF global_token->S == "="
@@ -2708,8 +2772,16 @@ Missing ]
 	mov_eax,[DWORD] &global_token               # Using global_token
 	mov_eax,[eax]                               # global_token->NEXT
 	mov_[DWORD],eax &global_token               # global_token = global_token->NEXT
+	cmp_eax, !0                                 # IF we hit EOF
+	je %Exit_Failure                            # Abort hard
 
 	mov_ebx,[eax+BYTE] !8                       # Using global_token->S
+	mov_eax,[DWORD] &current_target             # Using current_target
+	cmp_eax, !0                                 # IF target is unknown
+	je %Exit_Failure                            # Abort hard
+	mov_eax,[eax+BYTE] !16                      # current_target->MEMBERS
+	cmp_eax, !0                                 # IF target has no members
+	je %Exit_Failure                            # Abort hard
 	mov_eax,[DWORD] &current_target             # Using current_target
 	call %lookup_member                         # lookup_member(current_target, global_token->s)
 	mov_ebx,eax                                 # struct type* I = lookup_member(current_target, global_token->s)
@@ -2743,6 +2815,8 @@ Missing ]
 
 	# Last chance for load
 	mov_eax,[DWORD] &global_token               # Using global_token
+	cmp_eax, !0                                 # IF we hit EOF
+	je %postfix_expr_arrow_load                 # Treat it as not being an assignment
 	mov_ebx,[eax+BYTE] !8                       # global_token->S
 	mov_eax, &equal                             # Using "="
 	call %match                                 # IF global_token->S == "="
@@ -2750,6 +2824,7 @@ Missing ]
 	je %postfix_expr_arrow_done                 # Be done
 
 	# Deal with load case
+:postfix_expr_arrow_load
 	mov_eax, &postfix_expr_arrow_string_3       # Using "mov_eax,[eax]\n"
 	call %emit_out                              # Emit it
 
@@ -2775,6 +2850,8 @@ add_eax,ebx
 	push_ebx                                    # Protect EBX
 
 	mov_eax,[DWORD] &global_token               # Using global_token
+	cmp_eax, !0                                 # Check for EOF
+	je %Exit_Failure                            # Missing expression
 	mov_ebx,[eax+BYTE] !8                       # global_token->S
 	mov_eax, &sizeof_string                     # Using "sizeof"
 	call %match                                 # See if match
@@ -3063,6 +3140,8 @@ Didn't get )
 	call %emit_out                              # Emit it
 
 	mov_eax,[DWORD] &global_token               # Using global_token
+	cmp_eax, !0                                 # Check for EOF
+	je %function_call_gen_done                  # Missing ) will be reported below
 	mov_eax,[eax+BYTE] !8                       # global_token->S
 	mov_al,[eax]                                # global_token->S[0]
 	movzx_eax,al                                # Make it useful
@@ -3078,6 +3157,8 @@ Didn't get )
 
 :function_call_gen_iter
 	mov_eax,[DWORD] &global_token               # Using global_token
+	cmp_eax, !0                                 # Check for EOF
+	je %function_call_gen_done                  # Missing ) will be reported below
 	mov_eax,[eax+BYTE] !8                       # global_token->S
 	mov_al,[eax]                                # global_token->S[0]
 	movzx_eax,al                                # Make it useful
@@ -3208,6 +3289,8 @@ mov_eax,[eax]
 	mov_ecx,eax                                 # Protect A
 
 	mov_ebx,[DWORD] &global_token               # Using global_token
+	cmp_ebx, !0                                 # Check for EOF
+	je %variable_load_regular                   # EOF means not a call
 	mov_ebx,[ebx+BYTE] !8                       # global_token->S
 	mov_eax, &open_paren                        # Using "("
 	call %match                                 # IF global_token->S == "("
@@ -3244,6 +3327,8 @@ mov_eax,[eax]
 
 	# Check for special case of assignment
 	mov_ebx,[DWORD] &global_token               # Using global_token
+	cmp_ebx, !0                                 # Check for EOF
+	je %variable_load_value                     # EOF means not an assignment
 	mov_ebx,[ebx+BYTE] !8                       # global_token->S
 	mov_eax, &equal                             # Using "="
 	call %match                                 # IF global_token->S == "="
@@ -3251,6 +3336,7 @@ mov_eax,[eax]
 	je %variable_load_done                      # And be done
 
 	# Deal with common case
+:variable_load_value
 	mov_eax, &variable_load_string_2            # Using "mov_eax,[eax]\n"
 	call %emit_out                              # Emit it
 
@@ -3276,6 +3362,8 @@ mov_eax,[eax]
 	mov_eax,[eax+BYTE] !8                       # A->S
 	mov_ecx,eax                                 # Protect A->S
 	mov_ebx,[DWORD] &global_token               # Using global_token
+	cmp_ebx, !0                                 # Check for EOF
+	je %function_load_regular                   # EOF means not a call
 	mov_ebx,[ebx+BYTE] !8                       # global_token->S
 	mov_eax, &open_paren                        # Using "("
 	call %match                                 # IF global_token->S == "("
@@ -3330,6 +3418,8 @@ mov_eax,[eax]
 	call %emit_out                              # Emit it
 
 	mov_ebx,[DWORD] &global_token               # Using global_token
+	cmp_ebx, !0                                 # Check for EOF
+	je %global_load_value                       # EOF means this is not an assignment
 	mov_ebx,[ebx+BYTE] !8                       # global_token->S
 	mov_eax, &equal                             # "="
 	call %match                                 # IF global_token->S == "="
@@ -3337,6 +3427,7 @@ mov_eax,[eax]
 	je %global_load_done                        # and be done
 
 	# Otherwise we are loading the contents
+:global_load_value
 	mov_eax, &global_load_string_2              # Using "mov_eax,[eax]\n"
 	call %emit_out                              # Emit it
 
@@ -3529,6 +3620,8 @@ mov_eax,[eax]
 	mov_ecx,ebx                                 # Protect S
 
 	mov_ebx,[DWORD] &global_token               # Using global_token
+	cmp_ebx, !0                                 # Check for EOF
+	je %general_recursion_done                  # Nothing left to match
 	mov_ebx,[ebx+BYTE] !8                       # global_token->S
 	call %match                                 # IF match(name, global_token->s)
 	cmp_eax, !0                                 # If true we do
@@ -3646,11 +3739,14 @@ mov_eax,[eax]
 	push_ecx                                    # Protect ECX
 	mov_ecx,eax                                 # put the message somewhere safe
 	mov_eax,[DWORD] &global_token               # Using global_token
+	cmp_eax, !0                                 # Check for EOF
+	je %require_match_bad                       # Missing required token
 	mov_eax,[eax+BYTE] !8                       # global_token->S
 	call %match                                 # IF required == global_token->S
 	cmp_eax, !0                                 # we are fine
 	je %require_match_good                      # otherwise pain
 
+:require_match_bad
 	# Deal will bad times
 #	call %line_error                            # Tell user what went wrong
 	mov_eax, %2                                 # Using standard error
@@ -4099,6 +4195,8 @@ mov_eax,[eax]
 	push_ebx                                    # Protect EBX
 	push_ecx                                    # Protect ECX
 	mov_ebx,[DWORD] &global_token               # Using global_token
+	cmp_ebx, !0                                 # IF we hit EOF
+	je %Exit_Failure                            # Abort hard
 	mov_ebx,[ebx+BYTE] !8                       # global_token->S
 	mov_eax, &struct                            # Using "struct"
 	call %match                                 # IF global_token->S == "struct"
@@ -4110,6 +4208,8 @@ mov_eax,[eax]
 	mov_ebx,[DWORD] &global_token               # Using global_token
 	mov_ebx,[ebx]                               # global_token->next
 	mov_[DWORD],ebx &global_token               # global_token = global_token->next
+	cmp_ebx, !0                                 # IF we hit EOF
+	je %Exit_Failure                            # Abort hard
 	mov_eax,[ebx+BYTE] !8                       # global_token->S
 	mov_ebx,[DWORD] &global_types               # get all known types
 	call %lookup_type                           # Find type if possible
@@ -4155,6 +4255,8 @@ mov_eax,[eax]
 	mov_[DWORD],ebx &global_token               # global_token = global_token->next
 
 :type_name_iter
+	cmp_ebx, !0                                 # Check for EOF
+	je %type_name_done                          # No more pointer qualifiers
 	mov_eax,[ebx+BYTE] !8                       # global_token->S
 	mov_al,[eax]                                # global_token->S[0]
 	movzx_eax,al                                # make it useful
@@ -4239,6 +4341,8 @@ mov_eax,[eax]
 
 	mov_[edx+BYTE],ebp !12                      # HEAD->INDIRECT = I
 	mov_[ebp+BYTE],edx !12                      # I->INDIRECT = HEAD
+	mov_[edx+BYTE],edx !20                      # HEAD->TYPE = HEAD
+	mov_[ebp+BYTE],ebp !20                      # I->TYPE = I
 
 	mov_eax,[DWORD] &global_types               # Using global_types
 	mov_[edx],eax                               # HEAD->NEXT = global_types
@@ -4259,6 +4363,8 @@ mov_eax,[eax]
 
 :create_struct_iter
 	mov_eax,[DWORD] &global_token               # Using global_token
+	cmp_eax, !0                                 # IF we hit EOF
+	je %Exit_Failure                            # Abort hard
 	mov_eax,[eax+BYTE] !8                       # global_token->S
 	mov_al,[eax]                                # global_token->S[0]
 	movzx_eax,al                                # Make it useful
@@ -4384,10 +4490,14 @@ mov_eax,[eax]
 	mov_ecx,eax                                 # Put in place
 	mov_[edx+BYTE],ecx !20                      # I->TYPE = MEMBER_TYPE
 	mov_eax,[DWORD] &global_token               # Using global_token
+	cmp_eax, !0                                 # IF we hit EOF
+	je %Exit_Failure                            # Abort hard
 	mov_ebx,[eax+BYTE] !8                       # global_token->S
 	mov_[edx+BYTE],ebx !24                      # I->NAME = global_token->S
 	mov_eax,[eax]                               # global_token->NEXT
 	mov_[DWORD],eax &global_token               # global_token = global_token->NEXT
+	cmp_eax, !0                                 # IF we hit EOF
+	je %build_member_non_array                  # Let the caller report the missing semicolon
 
 	# Check if we have an array
 	mov_ebx,[eax+BYTE] !8                       # global_token->S
@@ -4397,6 +4507,7 @@ mov_eax,[eax]
 	je %build_member_array                      # So deal with that pain
 
 	# Deal with non-array case
+:build_member_non_array
 	mov_eax,[ecx+BYTE] !4                       # member_type->SIZE
 	mov_[edx+BYTE],eax !4                       # I->SIZE = member_type->SIZE
 	jmp %build_member_done                      # Be done
@@ -4405,6 +4516,8 @@ mov_eax,[eax]
 	mov_eax,[DWORD] &global_token               # Using global_token
 	mov_eax,[eax]                               # global_token->NEXT
 	mov_[DWORD],eax &global_token               # global_token = global_token->NEXT
+	cmp_eax, !0                                 # IF we hit EOF
+	je %Exit_Failure                            # Abort hard
 
 	mov_eax,[eax+BYTE] !8                       # global_token->S
 	call %numerate_string                       # convert number

--- a/test/cc_x86-fuzz.sh
+++ b/test/cc_x86-fuzz.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+set -eu
+
+tmp=${TMPDIR:-/tmp}/cc_x86-fuzz.$$
+mkdir -p "$tmp"
+trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+
+as --32 GAS/cc_x86.S -o "$tmp/cc_x86.o"
+ld -melf_i386 "$tmp/cc_x86.o" -o "$tmp/cc_x86"
+
+check_no_crash()
+{
+	name=$1
+	input=$2
+	printf '%s' "$input" > "$tmp/$name.c"
+	set +e
+	timeout 2 "$tmp/cc_x86" "$tmp/$name.c" "$tmp/$name.M1" >/dev/null 2>&1
+	status=$?
+	set -e
+	if [ "$status" -eq 124 ]; then
+		echo "$name timed out"
+		exit 1
+	fi
+	if [ "$status" -ge 128 ]; then
+		echo "$name crashed with status $status"
+		exit 1
+	fi
+}
+
+check_no_crash unterminated-string '"'
+check_no_crash line-comment-eof 'int#main() { return 0; }'
+check_no_crash block-comment-eof '/*'
+check_no_crash global-declarator-eof 'int 0'
+check_no_crash global-open-paren-eof 'int('
+check_no_crash global-close-brace-eof 'int}'
+check_no_crash global-quote-eof 'int"'
+check_no_crash global-single-quote-eof "int'"
+check_no_crash function-arguments-eof 'int 0('
+check_no_crash function-declaration-eof 'int 0()'
+check_no_crash function-expression-eof 'int 0()0'
+check_no_crash function-return-eof 'int 0()return'
+check_no_crash function-body-eof 'int 0(){'
+check_no_crash function-body-statement-eof 'int 0(){0;'
+check_no_crash function-if-eof 'int 0()if(0)'
+check_no_crash function-return-unary-eof 'int 0()return~'
+check_no_crash function-local-name-eof 'int 0()int'
+check_no_crash function-global-load-eof 'int x;int 0()x'
+check_no_crash function-name-load-eof 'int n()n'
+check_no_crash function-local-delimiter-eof 'int 0(){0;int}'
+check_no_crash function-local-declaration-eof 'int 0()int 0'
+check_no_crash function-if-no-else-eof 'int 0()if(0)0;'
+check_no_crash function-array-target-eof 'int 0()0[0'
+check_no_crash function-call-open-eof 'int m0in()return m0in('
+check_no_crash function-local-load-eof 'int 0(){int i;i'
+check_no_crash enum-open-eof 'enum {'
+check_no_crash enum-value-eof 'enum { A ='
+check_no_crash enum-comma-eof 'enum { A = 1,'
+check_no_crash asm-open-eof 'int main() asm('
+check_no_crash asm-string-eof 'int main() asm("x"'
+check_no_crash for-open-eof 'int main() for('
+check_no_crash sizeof-open-eof 'int main() return sizeof('
+check_no_crash struct-open-eof 'struct s {'
+check_no_crash struct-member-type-eof 'struct s { int'
+check_no_crash struct-array-open-eof 'struct s { int x['
+check_no_crash arrow-member-eof 'struct s { int x; }; int main(){ struct s *p; p->'
+check_no_crash arrow-load-eof 'struct s { int x; }; int main(){ struct s *p; p->x'
+check_no_crash goto-label-eof 'int main() goto'
+check_no_crash scalar-array-index-eof 'int n(){int x;x[0]'
+check_no_crash struct-array-load-eof 'struct S{char*s;int y[4];};int n(){struct S*p;p->s="";return p->y[0]'
+check_no_crash scalar-arrow-member-eof 'int n(){int x;1->y'
+check_no_crash struct-array-member-type-eof 'struct S{S e[a'


### PR DESCRIPTION
Harden the bootstrap compiler against malformed/truncated input discovered by fuzzing.
This adds EOF/null guards so invalid source fails cleanly instead of crashing.
