### PR TITLE
Fix stale token buffer suffixes

### DIFF
--- a/GAS/cc_amd64.S
+++ b/GAS/cc_amd64.S
@@ -452,6 +452,8 @@ consume_byte:
 	mov ebx, [string_index]     # S[0]
 	mov [ebx], al               # S[0] = C
 	add ebx, 1                  # S = S + 1
+	mov eax, 0                  # NULL terminate S
+	mov [ebx], al               # S[0] = NULL
 	mov [string_index], ebx     # Update S
 	call fgetc
 	pop ebx                     # Restore EBX

--- a/GAS/cc_x86.S
+++ b/GAS/cc_x86.S
@@ -462,6 +462,8 @@ consume_byte:
 	mov ebx, [string_index]     # S[0]
 	mov [ebx], al               # S[0] = C
 	add ebx, 1                  # S = S + 1
+	mov eax, 0                  # NULL terminate S
+	mov [ebx], al               # S[0] = NULL
 	mov [string_index], ebx     # Update S
 	call fgetc
 	pop ebx                     # Restore EBX

--- a/cc_x86.M1
+++ b/cc_x86.M1
@@ -609,6 +609,8 @@ DEFINE xchg_eax,ebx 93
 	mov_ebx,[DWORD] &string_index               # S[0]
 	mov_[ebx],al                                # S[0] = C
 	add_ebx, !1                                 # S = S + 1
+	mov_eax, %0                                 # NULL terminate S
+	mov_[ebx],al                                # S[0] = NULL
 	mov_[DWORD],ebx &string_index               # Update S
 	call %fgetc
 	pop_ebx                                     # Restore EBX


### PR DESCRIPTION
NUL-terminate the token buffer after each consumed byte so shorter tokens cannot retain stale suffix data.